### PR TITLE
공지사항 조회 기능에 로컬 캐시, 글로버 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // aop
+    implementation 'org.springframework:spring-aop'
+
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -42,6 +45,12 @@ dependencies {
     // database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 
     // querydsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"

--- a/src/main/java/admin/adminsiteserver/announcement/application/AnnouncementQueryService.java
+++ b/src/main/java/admin/adminsiteserver/announcement/application/AnnouncementQueryService.java
@@ -5,6 +5,7 @@ import admin.adminsiteserver.announcement.ui.response.AnnouncementResponse;
 import admin.adminsiteserver.announcement.ui.response.AnnouncementSimpleResponse;
 import admin.adminsiteserver.announcement.domain.Announcement;
 import admin.adminsiteserver.announcement.domain.AnnouncementRepository;
+import admin.adminsiteserver.common.cache.LayeredCacheable;
 import admin.adminsiteserver.common.response.PageInformation;
 import admin.adminsiteserver.common.response.PageResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class AnnouncementQueryService {
         return AnnouncementResponse.from(announcement);
     }
 
+    @LayeredCacheable(cacheName = "announcements", key = "announcementId")
     public PageResponse<List<AnnouncementSimpleResponse>> announcements(Long announcementId, Pageable pageable) {
         Pageable param = getSortedPageable(pageable);
         Page<AnnouncementSimpleResponse> announcements = findAll(announcementId, param);

--- a/src/main/java/admin/adminsiteserver/announcement/application/AnnouncementService.java
+++ b/src/main/java/admin/adminsiteserver/announcement/application/AnnouncementService.java
@@ -7,6 +7,7 @@ import admin.adminsiteserver.announcement.ui.request.CommentRequest;
 import admin.adminsiteserver.announcement.ui.request.AnnouncementRequest;
 import admin.adminsiteserver.announcement.domain.Announcement;
 import admin.adminsiteserver.announcement.domain.AnnouncementRepository;
+import admin.adminsiteserver.common.cache.LayeredCacheEvict;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,17 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnouncementService {
     private final AnnouncementRepository announcementRepository;
 
+    @LayeredCacheEvict(cacheName = "announcements")
     public Long upload(AnnouncementRequest request, Author author) {
         Announcement announcement = request.toEntity(author);
         announcementRepository.save(announcement);
         return announcement.getId();
     }
 
+    @LayeredCacheEvict(cacheName = "announcements")
     public void update(Long announcementId, AnnouncementRequest request, Author author) {
         Announcement announcement = findById(announcementId);
         announcement.update(request.getTitle(), request.getContent(), request.getAnnouncementFiles(), author);
     }
 
+    @LayeredCacheEvict(cacheName = "announcements")
     public void delete(Long announcementId, Author author) {
         Announcement announcement = findById(announcementId);
         announcement.delete(author);

--- a/src/main/java/admin/adminsiteserver/announcement/ui/response/AnnouncementSimpleResponse.java
+++ b/src/main/java/admin/adminsiteserver/announcement/ui/response/AnnouncementSimpleResponse.java
@@ -1,6 +1,10 @@
 package admin.adminsiteserver.announcement.ui.response;
 
 import admin.adminsiteserver.announcement.domain.Announcement;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +22,13 @@ public class AnnouncementSimpleResponse {
     private String authorRole;
     private String title;
     private String content;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime createAt;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime modifiedAt;
 
     public static AnnouncementSimpleResponse from(Announcement announcement) {

--- a/src/main/java/admin/adminsiteserver/common/cache/CacheEvent.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/CacheEvent.java
@@ -1,0 +1,20 @@
+package admin.adminsiteserver.common.cache;
+
+public class CacheEvent {
+    private final String key;
+
+    private final CacheEventType type;
+
+    private CacheEvent(String key, CacheEventType type) {
+        this.key = key;
+        this.type = type;
+    }
+
+    public static CacheEvent put(String key) {
+        return new CacheEvent(key, CacheEventType.PUT);
+    }
+
+    public static CacheEvent evict(String key) {
+        return new CacheEvent(key, CacheEventType.EVICT);
+    }
+}

--- a/src/main/java/admin/adminsiteserver/common/cache/CacheEventType.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/CacheEventType.java
@@ -1,0 +1,5 @@
+package admin.adminsiteserver.common.cache;
+
+public enum CacheEventType {
+    PUT, EVICT;
+}

--- a/src/main/java/admin/adminsiteserver/common/cache/CaffeineCacheType.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/CaffeineCacheType.java
@@ -1,0 +1,29 @@
+package admin.adminsiteserver.common.cache;
+
+public enum CaffeineCacheType {
+    ANNOUNCEMENTS("announcements", 5 * 60, 10_000);
+
+    private final String cacheName;
+
+    private final int expireAfterWrite;
+
+    private final int maximumSize;
+
+    CaffeineCacheType(String cacheName, int expireAfterWrite, int maximumSize) {
+        this.cacheName = cacheName;
+        this.expireAfterWrite = expireAfterWrite;
+        this.maximumSize = maximumSize;
+    }
+
+    public String cacheName() {
+        return cacheName;
+    }
+
+    public int expireAfterWrite() {
+        return expireAfterWrite;
+    }
+
+    public int maximumSize() {
+        return maximumSize;
+    }
+}

--- a/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheAspect.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheAspect.java
@@ -1,0 +1,90 @@
+package admin.adminsiteserver.common.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LayeredCacheAspect {
+    private final CacheManager caffeineCacheManager;
+
+    private final CacheManager redisCacheManager;
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Around("@annotation(LayeredCacheable)")
+    public Object cacheable(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        LayeredCacheable cacheable = methodSignature.getMethod().getAnnotation(LayeredCacheable.class);
+        String cacheName = cacheable.cacheName();
+        String key = key(methodSignature, cacheable.key());
+
+        Cache caffeineCache = findCaffeineCacheByName(cacheName);
+        Cache redisCache = findRedisCacheByName(cacheName);
+
+        var caffeineCacheValue = caffeineCache.get(key);
+        if (caffeineCacheValue != null) {
+            return caffeineCacheValue.get();
+        }
+
+        var redisCacheValue = redisCache.get(key);
+        if (redisCacheValue != null) {
+            caffeineCache.put(key, redisCacheValue.get());
+            return redisCacheValue.get();
+        }
+
+        Object result = joinPoint.proceed(joinPoint.getArgs());
+        caffeineCache.put(key, result);
+        redisCache.put(key, result);
+
+        eventPublisher.publishEvent(CacheEvent.put(key));
+        return result;
+    }
+
+    @Around("@annotation(LayeredCacheEvict)")
+    public void cacheEvict(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        LayeredCacheable cacheable = methodSignature.getMethod().getAnnotation(LayeredCacheable.class);
+        String cacheName = cacheable.cacheName();
+        String key = key(methodSignature, cacheable.key());
+
+        joinPoint.proceed(joinPoint.getArgs());
+
+        Cache caffeineCache = findCaffeineCacheByName(cacheName);
+        Cache redisCache = findRedisCacheByName(cacheName);
+
+        caffeineCache.evict(key);
+        redisCache.evict(key);
+        eventPublisher.publishEvent(CacheEvent.evict(key));
+    }
+
+    private Cache findRedisCacheByName(String cacheName) {
+        return Objects.requireNonNull(redisCacheManager.getCache(cacheName),
+                "redis cache is null. cacheName: " + cacheName);
+    }
+
+    private Cache findCaffeineCacheByName(String cacheName) {
+        return Objects.requireNonNull(caffeineCacheManager.getCache(cacheName),
+                "caffeine cache is null. cacheName: " + cacheName);
+    }
+
+    private String key(MethodSignature methodSignature, String key) {
+        return Arrays.stream(methodSignature.getParameterNames())
+                .filter(param -> param.equals(key))
+                .findAny()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheEvict.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheEvict.java
@@ -1,0 +1,14 @@
+package admin.adminsiteserver.common.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LayeredCacheEvict {
+    String cacheName() default "";
+
+    String key() default "";
+}

--- a/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheable.java
+++ b/src/main/java/admin/adminsiteserver/common/cache/LayeredCacheable.java
@@ -1,0 +1,14 @@
+package admin.adminsiteserver.common.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LayeredCacheable {
+    String cacheName() default "";
+
+    String key() default "";
+}

--- a/src/main/java/admin/adminsiteserver/common/config/CacheConfig.java
+++ b/src/main/java/admin/adminsiteserver/common/config/CacheConfig.java
@@ -1,0 +1,57 @@
+package admin.adminsiteserver.common.config;
+
+import admin.adminsiteserver.common.cache.CaffeineCacheType;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Configuration
+public class CacheConfig extends CachingConfigurerSupport {
+    @Autowired
+    private RedisConnectionFactory connectionFactory;
+
+    @Bean
+    public CacheManager caffeineCacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caffeineCaches());
+        return cacheManager;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    private List<CaffeineCache> caffeineCaches() {
+        return Arrays.stream(CaffeineCacheType.values())
+                .map(cache -> new CaffeineCache(cache.cacheName(), Caffeine.newBuilder()
+                        .recordStats()
+                        .expireAfterWrite(cache.expireAfterWrite(), TimeUnit.SECONDS)
+                        .maximumSize(cache.maximumSize())
+                        .build()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/admin/adminsiteserver/common/response/PageInformation.java
+++ b/src/main/java/admin/adminsiteserver/common/response/PageInformation.java
@@ -1,17 +1,25 @@
 package admin.adminsiteserver.common.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class PageInformation {
     private int currentPage;
     private int totalPages;
     private int numberOfElements;
     private int pageSize;
     private int totalElements;
+
+    public PageInformation(int currentPage, int totalPages, int numberOfElements, int pageSize, int totalElements) {
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.numberOfElements = numberOfElements;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+    }
 
     public static <T> PageInformation from(Page<T> page) {
         return new PageInformation(

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,3 +6,7 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create-drop
+
+  redis:
+    host: localhost
+    port: 6379

--- a/src/test/java/admin/adminsiteserver/AcceptanceTest.java
+++ b/src/test/java/admin/adminsiteserver/AcceptanceTest.java
@@ -3,6 +3,7 @@ package admin.adminsiteserver;
 import admin.adminsiteserver.aws.infrastructure.S3Uploader;
 import admin.adminsiteserver.member.domain.Member;
 import admin.adminsiteserver.member.domain.MemberRepository;
+import admin.adminsiteserver.utils.CacheCleanup;
 import admin.adminsiteserver.utils.DatabaseCleanup;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,9 @@ public class AcceptanceTest {
     private DatabaseCleanup databaseCleanup;
 
     @Autowired
+    protected CacheCleanup cacheCleanup;
+
+    @Autowired
     protected MemberRepository memberRepository;
 
     @Autowired
@@ -43,6 +47,7 @@ public class AcceptanceTest {
             databaseCleanup.afterPropertiesSet();
         }
         databaseCleanup.execute();
+        cacheCleanup.execute();
         saveMembers();
     }
 

--- a/src/test/java/admin/adminsiteserver/config/EmbeddedRedisConfig.java
+++ b/src/test/java/admin/adminsiteserver/config/EmbeddedRedisConfig.java
@@ -1,0 +1,66 @@
+package admin.adminsiteserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@Configuration
+public class EmbeddedRedisConfig {
+    @Value("${spring.redis.port}")
+    private int port;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int port = isRedisRunning()? findAvailablePort() : this.port;
+        redisServer = new RedisServer(port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(port));
+    }
+
+    public int findAvailablePort() throws IOException {
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+        } catch (Exception ignored) {
+        }
+        return StringUtils.hasText(pidInfo.toString());
+    }
+}

--- a/src/test/java/admin/adminsiteserver/utils/CacheCleanup.java
+++ b/src/test/java/admin/adminsiteserver/utils/CacheCleanup.java
@@ -1,0 +1,35 @@
+package admin.adminsiteserver.utils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Profile("test")
+@Component
+public class CacheCleanup {
+    @Autowired
+    private CacheManager caffeineCacheManager;
+
+    @Autowired
+    private CacheManager redisCacheManager;
+
+    public void execute() {
+        List<String> caffeineCacheNames = new ArrayList<>(caffeineCacheManager.getCacheNames());
+        List<String> redisCacheNames = new ArrayList<>(redisCacheManager.getCacheNames());
+
+        caffeineCacheNames.stream()
+                .map(caffeineCacheManager::getCache)
+                .filter(Objects::nonNull)
+                .forEach(Cache::clear);
+        redisCacheNames.stream()
+                .map(redisCacheManager::getCache)
+                .filter(Objects::nonNull)
+                .forEach(Cache::clear);
+    }
+}


### PR DESCRIPTION
안녕하세요~

공지사항 조회 기능에 멀티 레벨 캐시(로컬 캐시, 글로벌 캐시)를 적용했습니다.
로컬 캐시를 사용할 경우 글로벌 캐시를 사용하는 것보다 빠르게 조회할 수 있지만 캐시 간 정합성 문제가 발생할 수 있습니다.
글로벌 캐시를 사용할 경우 데이터베이스에서 직접 조회하는 것보다 빠르지만, 네트워크 비용이 발생합니다.
이 두 장점을 모두 얻고자 멀티 레벨 캐시를 구성했습니다.
글로벌 캐시로는 redis, 로컬 캐시로는 caffeineCache를 사용했습니다.

### Cacheable
1. local cache에 해당 키값의 데이터가 있는 경우 반환합니다.
2. local cache에 값이 없으면 global cache를 확인합니다. global cache에 값이 있다면 반환합니다.
3. global cache에도 값이 없다면 데이터베이스에서 조회하고 이 값을 local, global cache에 저장합니다.
4. cache put 이벤트를 발행합니다.
5. 이 이벤트를 구독하는 다른 인스턴스에서는 global cache의 데이터를 local cache에 반영합니다.

### CacheEvict
1. local, global cache의 값을 비웁니다.
2. cache evict 이벤트를 발행합니다.
3. 이 이벤트를 구독하는 다른 인스턴스에서는 local, global cache를 비웁니다.

여러 인스턴스를 운영할 일이 없어 우선은 applicationEventPublisher로 이벤트만 발행해놨습니다.
이후에 필요에 따라 application event를 수신해서 큐로 쏘는 기능만 추가하면 될 것 같습니다.

추가로, 각 레이어의 캐시를 추상화해서 구현해 볼까?라고 생각했다가,
이전 조영호님 특강에서 말씀하셨듯이 변경 가능성이 없는 부분은 굳이 추상화를 하기보다는
절차 지향적으로 작성하여 이해를 높이는 것이 낫다고 생각해서 이와 같이 작성했습니다.
(캐시 레이어가 추가될 가능성이 없다고 생각했습니다.)